### PR TITLE
Fix feed updating

### DIFF
--- a/source.py
+++ b/source.py
@@ -68,6 +68,7 @@ class YandexMusicSource(RB.BrowserSource):
                 track_location = track_location+':'+str(track.albums[0].id)
             entry = self.db.entry_lookup_by_location(track_location)
             if not entry:
+                self.last_track = str(track.id)+':'+str(track.albums[0].id)
                 entry = RB.RhythmDBEntry.new(self.db, self.entry_type, track_location)
                 if entry:
                     self.db.entry_set(entry, RB.RhythmDBPropType.TITLE, track.title)
@@ -81,7 +82,6 @@ class YandexMusicSource(RB.BrowserSource):
                     self.album_arts.ensure_art_exists(track)
         self.iterator += 1
         if self.iterator >= self.listcount:
-            self.last_track = str(track.id)+':'+str(track.albums[0].id)
             return False
         else:
             return True


### PR DESCRIPTION
Данный реквест частично фиксит проблему в ишью #6 
Иногда, из-за асинхронности, в last_track записывается фактически не последний трек плейлиста, но тем не менее туда записывается гарантированно один из следующих треков по порядку воспроизведения. 
При локальных тестах, в 9 из 10 случаев трек всё же был последний. Сломаться оно может при двойном стечении обствоятельст: если запишется не последний трек и если пользователь руками сам кликнет на последний, тем самым пропустив трек, на котором должен был обновиться фид. Не придумал как сделать лучше, на локальных тестах такой подход проработал без ошибок весь день.